### PR TITLE
add hc138 spi chip-select mux

### DIFF
--- a/esphome/components/hc138/__init__.py
+++ b/esphome/components/hc138/__init__.py
@@ -1,0 +1,57 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi, gpio
+from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID, CONF_PIN, CONF_SPI_ID, CONF_MISO_PIN
+from esphome import pins
+
+CODEOWNERS = ["@wizath"]
+
+DEPENDENCIES = ["spi"]
+
+hc138_ns = cg.esphome_ns.namespace("hc138")
+HC138Component = hc138_ns.class_("HC138Component", cg.Component, spi.SPIDevice)
+HC138Channel = hc138_ns.class_("HC138Channel", spi.SPIComponent)
+
+MULTI_CONF = True
+CONF_AO = "a0"
+CONF_A1 = "a1"
+CONF_A2 = "a2"
+
+CONF_BUS_ID = "bus_id"
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(HC138Component),
+            cv.Optional(CONF_CHANNELS, default=[]): cv.ensure_list(
+                {
+                    cv.Required(CONF_BUS_ID): cv.declare_id(HC138Channel),
+                    cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=3),
+                }
+            ),
+            cv.Required(CONF_AO): pins.gpio_output_pin_schema,
+            cv.Required(CONF_A1): pins.gpio_output_pin_schema,
+            cv.Required(CONF_A2): pins.gpio_output_pin_schema,
+        }
+    )
+    .extend(spi.spi_device_schema(cs_pin_required=False))
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)
+    
+    a0 = await cg.gpio_pin_expression(config[CONF_AO])
+    a1 = await cg.gpio_pin_expression(config[CONF_A1])
+    a2 = await cg.gpio_pin_expression(config[CONF_A2])
+    cg.add(var.set_a0(a0))
+    cg.add(var.set_a1(a1))
+    cg.add(var.set_a2(a2))
+    
+    for conf in config[CONF_CHANNELS]:
+        chan = cg.new_Pvariable(conf[CONF_BUS_ID])
+        await cg.register_component(chan, config)
+        cg.add(chan.set_parent(var))
+        cg.add(chan.set_channel(conf[CONF_CHANNEL]))

--- a/esphome/components/hc138/hc138.cpp
+++ b/esphome/components/hc138/hc138.cpp
@@ -1,0 +1,64 @@
+#include "esphome/core/log.h"
+#include "hc138.h"
+
+namespace esphome {
+namespace hc138 {
+
+static const char *TAG = "hc138";
+
+spi::SPIDelegate *HC138Channel::register_device(spi::SPIClient *device, spi::SPIMode mode, spi::SPIBitOrder bit_order,
+                                                uint32_t data_rate, GPIOPin *cs_pin) {
+  if (parent_ == nullptr) {
+    ESP_LOGE(TAG, "Parent not set for channel %d", channel_);
+    return nullptr;
+  }
+
+  this->delegate_ = this->parent_->parent_->register_device(device, mode, bit_order, data_rate, cs_pin);
+  return new HC138SPIDelegate(this->channel_, this->parent_, this->delegate_);
+}
+
+void HC138Component::setup() {
+  a0_->setup();
+  a1_->setup();
+  a2_->setup();
+}
+
+void HC138Component::select_channel(uint8_t channel) {
+  ESP_LOGI(TAG, "selecting channel %d", channel);
+
+  a0_->digital_write(channel & 0x01);
+  a1_->digital_write((channel >> 1) & 0x01);
+  a2_->digital_write((channel >> 2) & 0x01);
+}
+
+void HC138SPIDelegate::transfer(uint8_t *data, size_t length) {
+  parent_delegate_->transfer(data, length);
+}
+
+uint8_t HC138SPIDelegate::transfer(uint8_t data) {
+  return parent_delegate_->transfer(data);
+}
+
+void HC138SPIDelegate::write(uint16_t data, size_t bits) {
+  parent_delegate_->write(data, bits);
+}
+
+void HC138SPIDelegate::read_array(uint8_t *data, size_t length) {
+  parent_delegate_->read_array(data, length);
+}
+
+void HC138SPIDelegate::write_array(const uint8_t *data, size_t length) {
+  parent_delegate_->write_array(data, length);
+}
+
+void HC138SPIDelegate::begin_transaction() {
+  parent_->select_channel(this->channel_);
+  parent_delegate_->begin_transaction();
+}
+
+void HC138SPIDelegate::end_transaction() {
+  parent_delegate_->end_transaction();
+}
+
+}  // namespace hc138
+}  // namespace esphome

--- a/esphome/components/hc138/hc138.h
+++ b/esphome/components/hc138/hc138.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome {
+namespace hc138 {
+
+class HC138Component;
+class HC138SPIDelegate;
+
+class HC138Channel : public spi::SPIComponent {
+ public:
+  void set_channel(uint8_t channel) { channel_ = channel; }
+  void set_parent(HC138Component *parent) { this->parent_ = parent; }
+
+  void setup() override {};
+  void dump_config() override {};
+  spi::SPIDelegate *register_device(spi::SPIClient *device, spi::SPIMode mode, spi::SPIBitOrder bit_order,
+                                    uint32_t data_rate, GPIOPin *cs_pin) override;
+
+ protected:
+  uint8_t channel_;
+  spi::SPIDelegate *delegate_;
+  HC138Component *parent_;
+  friend class HC138SPIDelegate;
+};
+
+class HC138Component : public Component,
+                       public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                             spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1KHZ> {
+ public:
+  void set_a0(GPIOPin *pin) { a0_ = pin; }
+  void set_a1(GPIOPin *pin) { a1_ = pin; }
+  void set_a2(GPIOPin *pin) { a2_ = pin; }
+  void setup() override;
+  void select_channel(uint8_t channel);
+
+ protected:
+  GPIOPin *a0_;
+  GPIOPin *a1_;
+  GPIOPin *a2_;
+  HC138Channel *ch;
+  friend class HC138Channel;
+};
+
+class HC138SPIDelegate : public spi::SPIDelegate {
+ public:
+  HC138SPIDelegate(uint8_t channel, HC138Component *parent, spi::SPIDelegate *parent_delegate)
+      : channel_(channel), parent_(parent), parent_delegate_(parent_delegate) {}
+
+  void transfer(uint8_t *data, size_t length) override;
+  uint8_t transfer(uint8_t data) override;
+  void write(uint16_t data, size_t bits) override;
+  void read_array(uint8_t *data, size_t length) override;
+  void write_array(const uint8_t *data, size_t length) override;
+  void begin_transaction() override;
+  void end_transaction() override;
+
+ private:
+  uint8_t channel_;
+  HC138Component *parent_;
+  spi::SPIDelegate *parent_delegate_;
+};
+
+}  // namespace hc138
+}  // namespace esphome

--- a/esphome/components/hc138/index.md
+++ b/esphome/components/hc138/index.md
@@ -1,0 +1,93 @@
+# HC138 SPI Multiplexer
+
+The HC138 component allows you to use the 74HC138/CD4051B 3-to-8 line decoder/demultiplexer to control multiple SPI devices on a single SPI bus. This is particularly useful when you need to connect multiple SPI devices that share the same SPI bus (MOSI, MISO, CLK) but have different CS pins.
+
+## Configuration
+
+```yaml
+# Example configuration
+spi:
+  id: spi0
+  clk_pin: GPIO14
+  mosi_pin: GPIO12
+  miso_pin: GPIO13
+
+hc138:
+  id: multiplex0
+  spi_id: spi0
+  a0: GPIO23  # Address pin A0
+  a1: GPIO22  # Address pin A1
+  a2: GPIO21  # Address pin A2
+  channels:
+    - bus_id: multiplex0ch0  # First channel
+      channel: 0
+    - bus_id: multiplex0ch1  # Second channel
+      channel: 1
+```
+
+### Configuration variables:
+
+- **id** (*Required*, ID): The ID to use for this HC138 multiplexer.
+- **spi_id** (*Required*, ID): The ID of the SPI bus to use.
+- **a0** (*Required*, Pin): The GPIO pin connected to address pin A0 of the HC138.
+- **a1** (*Required*, Pin): The GPIO pin connected to address pin A1 of the HC138.
+- **a2** (*Required*, Pin): The GPIO pin connected to address pin A2 of the HC138.
+- **channels** (*Required*, List): List of channels to use.
+  - **bus_id** (*Required*, ID): The ID to use for this channel.
+  - **channel** (*Required*, int): The channel number (0-7).
+
+## Example with Multiple Devices
+
+```yaml
+spi:
+  id: spi0
+  clk_pin: GPIO14
+  mosi_pin: GPIO12
+  miso_pin: GPIO13
+
+hc138:
+  id: multiplex0
+  spi_id: spi0
+  a0: GPIO23
+  a1: GPIO22
+  a2: GPIO21
+  channels:
+    - bus_id: multiplex0ch0
+      channel: 0
+    - bus_id: multiplex0ch1
+      channel: 1
+
+# Example using MAX31865 temperature sensor on channel 0
+sensor:
+  - platform: max31865
+    spi_id: multiplex0ch0
+    name: "Temperature Sensor 1"
+    cs_pin: GPIO15
+    rtd_wires: 3
+    reference_resistance: 3900 Ω
+    rtd_nominal_resistance: 1000 Ω
+
+  # Another MAX31865 on channel 1
+  - platform: max31865
+    spi_id: multiplex0ch1
+    name: "Temperature Sensor 2"
+    cs_pin: GPIO15
+    rtd_wires: 3
+    reference_resistance: 3900 Ω
+    rtd_nominal_resistance: 1000 Ω
+```
+
+## Working Principle
+
+The HC138 is a 3-to-8 line decoder/demultiplexer that allows you to control up to 8 different SPI devices using only 3 GPIO pins (A0, A1, A2). When you want to communicate with a specific device:
+
+1. The component sets the address pins (A0, A1, A2) to select the desired channel (0-7)
+2. The selected channel becomes active, allowing communication with the device on that channel
+3. The SPI communication proceeds normally through the shared SPI bus
+
+This setup allows you to connect up to 8 SPI devices while using only 3 additional GPIO pins for channel selection, instead of using a separate CS pin for each device.
+
+## See Also
+
+- [SPI Component](/components/spi/)
+- [MAX31865 Component](/components/sensor/max31865/) 

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -329,7 +329,7 @@ class SPIClient;
 
 class SPIComponent : public Component {
  public:
-  SPIDelegate *register_device(SPIClient *device, SPIMode mode, SPIBitOrder bit_order, uint32_t data_rate,
+  virtual SPIDelegate *register_device(SPIClient *device, SPIMode mode, SPIBitOrder bit_order, uint32_t data_rate,
                                GPIOPin *cs_pin);
   void unregister_device(SPIClient *device);
 


### PR DESCRIPTION
# What does this implement/fix?

add HC138 extender as SPI device. It's used to multiplex the SPI CS line with three address pins A0, A1, A2 and uses device CS pin as output-enable for the extender.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml

spi:
  id: spi0
  clk_pin: GPIO14
  mosi_pin: GPIO12
  miso_pin: GPIO13

hc138:
  id: multiplex0
  spi_id: spi0
  a0: GPIO23
  a1: GPIO22
  a2: GPIO21
  channels:
    - bus_id: multiplex0ch0
      channel: 0

sensor:
  - platform: max31865
    spi_id: multiplex0ch0
    name: "Living Room Temperature"
    cs_pin: GPIO15
    rtd_wires: 3
    reference_resistance: 3900 Ω
    rtd_nominal_resistance: 1000 Ω
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
