### PR TITLE
fix external_components compatibility: fallback for CONF_BUS_ID

### DIFF
--- a/esphome/components/addrspi/__init__.py
+++ b/esphome/components/addrspi/__init__.py
@@ -2,7 +2,12 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import spi
 import esphome.config_validation as cv
-from esphome.const import CONF_BUS_ID, CONF_CHANNEL, CONF_CHANNELS, CONF_ID
+from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID
+
+try:
+    from esphome.const import CONF_BUS_ID
+except ImportError:
+    CONF_BUS_ID = "bus_id"
 
 CODEOWNERS = ["@wizath"]
 DEPENDENCIES = ["spi"]

--- a/esphome/components/hc138/__init__.py
+++ b/esphome/components/hc138/__init__.py
@@ -2,7 +2,12 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import spi
 import esphome.config_validation as cv
-from esphome.const import CONF_BUS_ID, CONF_CHANNEL, CONF_CHANNELS, CONF_ID
+from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID
+
+try:
+    from esphome.const import CONF_BUS_ID
+except ImportError:
+    CONF_BUS_ID = "bus_id"
 
 CODEOWNERS = ["@wizath"]
 

--- a/esphome/components/tca9548a/__init__.py
+++ b/esphome/components/tca9548a/__init__.py
@@ -1,7 +1,12 @@
 import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
-from esphome.const import CONF_BUS_ID, CONF_CHANNEL, CONF_CHANNELS, CONF_ID, CONF_SCAN
+from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID, CONF_SCAN
+
+try:
+    from esphome.const import CONF_BUS_ID
+except ImportError:
+    CONF_BUS_ID = "bus_id"
 
 CODEOWNERS = ["@andreashergert1984"]
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
